### PR TITLE
Disable quote substitution in FScriptTextView.m

### DIFF
--- a/FScriptFramework/FScriptTextView.m
+++ b/FScriptFramework/FScriptTextView.m
@@ -144,6 +144,15 @@ static NSMutableCharacterSet *letterDigitUnderscoreCharacterSet;
   }
 } 
 
+- (id)initWithFrame:(NSRect)frameRect textContainer:(NSTextContainer *)container
+{
+  if ((self = [super initWithFrame:frameRect textContainer:container])) {
+    [self setAutomaticDashSubstitutionEnabled:NO];
+    [self setAutomaticQuoteSubstitutionEnabled:NO];
+  }
+  return self;
+}
+
 - (NSArray *)completionsForPartialWordRange:(NSRange)charRange indexOfSelectedItem:(NSInteger *)index
 {
   NSString *stringToComplete;


### PR DESCRIPTION
Fixes "F-Script syntax error: non ascii character detected" in OS X Mavericks when trying to create a string. See https://groups.google.com/forum/#!topic/f-script/FJVIhPtHGj4
